### PR TITLE
Changed the location of sgerrand's public signing key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN set -x && \
 
 # Install glibc: This is required for HUGO-extended (including SASS) to work.
 
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub \
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
 &&  wget "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-$GLIBC_VERSION.apk" \
 &&  apk --no-cache add "glibc-$GLIBC_VERSION.apk" \
 &&  rm "glibc-$GLIBC_VERSION.apk" \


### PR DESCRIPTION
The location of the public signing key for `alpine-pkg-glibc` has changed, this was causing builds to fail.
This PR corrects the URL.